### PR TITLE
don't set bucket name

### DIFF
--- a/cloud-formation/video-dashboard.yaml
+++ b/cloud-formation/video-dashboard.yaml
@@ -4,14 +4,10 @@ Parameters:
   WhitelistedIp:
     Type: String
     Description: IP range for the office
-  VideoDashboardUri:
-    Type: String
-    Description: URI of the video dashboard
 Resources:
   VideoDashboardBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: {Ref: VideoDashboardUri}
       AccessControl: Private
   VideoDashboardBucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
Its making writing changes in DEV hard/impossible! Let's just deal with an unintuitive bucket name, but lets add [tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html) to the cloudformation stack for management and organisation.
