### PR TITLE
Google charts

### DIFF
--- a/dashboard/app/charts.ts
+++ b/dashboard/app/charts.ts
@@ -1,0 +1,59 @@
+const google = window.google;
+
+export function DoubleLineChartOpts(title: string, max1: number, max2: number) {
+  return {
+    chart: {title, legend: {position: 'bottom'}},
+    height: 300,
+    axes: {
+      y: {
+        0: {range: {min: 0, max: max1}},
+        1: {range: {min: 0, max: max2}}
+      }
+    },
+    series: {
+      0: {axis: 0, targetAxisIndex: 0},
+      1: {axis: 1, targetAxisIndex: 1}
+    },
+    colors: ['#fb0', '#333']
+  };
+}
+
+
+
+interface RatioGraphOpts {
+  title: string;
+  height: number;
+  colors: string[];
+  isStacked: boolean;
+}
+
+export function RatioGraphOpts(title: string): RatioGraphOpts {
+ return {
+   title,
+   height: 400,
+   colors: ['#fb0', '#333'],
+   legend: 'bottom',
+   isStacked: false
+ };
+}
+
+interface ChartColumn {
+  type: string;
+  name: string;
+}
+export function ChartColumn(type: string, name: string): ChartColumn { return {type, name}; }
+
+export function ChartData(columns: ChartColumn[], data: any[]): DataTable {
+  const chartData = new google.visualization.DataTable();
+  columns.forEach(column => chartData.addColumn(column.type, column.name));
+  chartData.addRows(data);
+
+  return chartData;
+}
+
+export function drawRatioChart(element: HTMLScriptElement, options: RatioGraphOpts, data: DataTable): ColumnChart {
+  const chart = new google.visualization.Bar(element);
+  chart.draw(data, options);
+
+  return chart;
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6,91 +6,18 @@
       body {
         color: #333;
         font-size: 12px;
-        padding: 5px;
+        padding: 0;
       }
-
-      .bars-heading {
-        margin: 0 0 5px 0;
-      }
-      .bars-container {
-        border-bottom: 2px #d3d3d3 solid;
-        margin-top: 20px;
+      .charts {
         padding: 10px;
       }
-      .bars {
-        display: flex;
-        margin-bottom: 5px;
+      .chart {
         width: 100%;
       }
-      .bar {
-        flex-grow: 1;
-        border: 1px solid #ccc;
-        overflow: hidden;
-        font-family: monospace;
-        text-align: center;
-      }
-      .bar__full {
-        background: #333;
-        display: flex;
-        flex-direction: column-reverse;
-        height: 500px;
-        width: 100%;
-        color: #fff;
-      }
-      .bar__percent {
-        background: #fb0;
-        width: 100%;
-        color: #333;
-        display: flex;
-        flex-direction: column-reverse;
-        padding: 10px 0;
-      }
-      .bar__label {
-        padding: 8px;
-      }
-      .bar__ratio {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 100%;
-        padding: 10px 0;
-        flex-grow: 1;
-      }
-
-      .key {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-      }
-      .key__item {
-
-      }
-      .key__item::before {
-        display: inline-block;
-        width: 10px;
-        height: 10px;
-        background: #000;
-        content: ' ';
-        margin-right: 10px;
-        vertical-align: middle;
-      }
-      .key__item--total::before {
-        background: #333;
-      }
-      .key__item--segment::before {
-        background: #fb0;
-      }
-
-      .β {
-        vertical-align: super;
-        background: red;
-        color: #f1f1f1;
-        padding: 2px 8px;
-        border-radius: 4px;
-        font-size: 11px;
-        width: 24px;
-        height: 24px;
-        text-align: center;
+      .topbar {
+        padding: 10px;
+        border-bottom: 1px solid #ccc;
+        margin-bottom: 10px;
       }
     </style>
 </head>
@@ -98,11 +25,14 @@
 <body>
   <div id="app"></div>
   <script id="app-template" type="text/ractive">
-    <input type="month" name="date" value={{date}} />
-
-    <div id="play-embed-quantities"></div>
-    <div id="embed-ratios"></div>
-    <div id="video-embed-plays"></div>
+    <div class="topbar">
+      <input type="month" name="date" value={{date}} />
+    </div>
+    <div class="charts">
+      <div class="chart" id="play-embed-quantities"></div>
+      <div class="chart" id="embed-ratios"></div>
+      <div class="chart" id="video-embed-plays"></div>
+    </div>
   </script>
 
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -100,55 +100,22 @@
   <script id="app-template" type="text/ractive">
     <input type="month" name="date" value={{date}} />
 
-    <div class="bars-container">
-      <h1 class="bars-heading">How many articles have video embedded?</h1>
-      <div class="bars">
-        {{#embeddedVideoBars}}
-          {{>bar}}
-        {{/embeddedVideoBars}}
-      </div>
-      <ul class="key">
-        <li class="key__item key__item--total">All content produced</li>
-        <li class="key__item key__item--segment">Content with video embedded</li>
-      </ul>
-    </div>
-
-
-    <div class="bars-container">
-      <h1 class="bars-heading">How many videos are played whilst embedded in articles?{{>beta}}</h1>
-      <div class="bars">
-        {{#readyVsPlayBars}}
-          {{>bar}}
-        {{/readyVsPlayBars}}
-      </div>
-      <ul class="key">
-        <li class="key__item key__item--total">Total videos requested on articles</li>
-        <li class="key__item key__item--segment">Videos played on articles</li>
-      </ul>
-    </div>
-
-    {{#partial bar}}
-      <div class="bar">
-        <div class="bar__label">{{textLabel}}</div>
-        <div class="bar__full">
-          <div class="bar__percent" style="height: {{percent}}%">
-            {{percent}}%
-          </div>
-          <div class="bar__ratio" title="{{segment}} / {{total}}">{{{numberLabel}}}</div>
-        </div>
-      </div>
-    {{/partial}}
-
-    {{#partial beta}}
-      <span class="β" title="βeta - treat with caution">β</span>
-    {{/partial}}
+    <div id="play-embed-quantities"></div>
+    <div id="embed-ratios"></div>
+    <div id="video-embed-plays"></div>
   </script>
 
 
   <script src="jspm_packages/system.js"></script>
   <script src="config.js"></script>
+  <script type="text/javascript" src="//www.gstatic.com/charts/loader.js"></script>
   <script>
-      System.import('app/app').catch(e => console.log(e));
+      google.charts.load('current', {packages: ['corechart', 'line', 'bar']});
+      google.charts.setOnLoadCallback(go);
+
+      function go() {
+        System.import('app/app').catch(e => console.log(e));
+      }
   </script>
 
 </body>


### PR DESCRIPTION
![video-dash](https://cloud.githubusercontent.com/assets/31692/14612229/ef7db67a-058d-11e6-8fee-3db6388427d4.png)

Three things here:
- If we embed more content, do we get more plays?
- A general graph of the percentage of content that has video in it (we'd want this to become higher).
- A graph showing the difference between video requests and video plays. This should be a lot higher as it means that much video was served, but not played.
